### PR TITLE
Add two useful bag functions:

### DIFF
--- a/lib/bagit.php
+++ b/lib/bagit.php
@@ -543,6 +543,27 @@ class BagIt
             unset($this->bagInfoData[$key]);
         }
     }
+    
+    /**
+     * Remove all of the keys and values in the `bag-info.txt` file. Use with
+     * caution.
+     * 
+     * @return void
+     * @author Michael Joyce <ubermichael@gmail.com>
+     */
+    public function clearAllBagInfo() {
+        $this->bagInfoData = array();
+    }
+    
+    /**
+     * Return a list of all keys in the `bag-info.txt` file.
+     * 
+     * @return array
+     */
+    public function getBagInfoKeys() {
+        $this->_ensureBagInfoData();
+        return array_keys($this->bagInfoData);
+    }
 
     /**
      * This returns the value for a key from bagInfoData.

--- a/test/testbagit.php
+++ b/test/testbagit.php
@@ -334,6 +334,73 @@ class BagItTest extends PHPUnit_Framework_TestCase
         }
         rrmdir($tmp2);
     }
+    
+    public function testBagItClearAllBagInfo() {
+        $this->assertEquals(0, count($this->bag->bagInfoData));
+
+        $tmp2 = tmpdir();
+        try
+        {
+            mkdir($tmp2);
+            file_put_contents(
+                $tmp2 . "/bag-info.txt",
+                "Source-organization: University of Virginia Alderman Library\n" .
+                "Contact-name: Eric Rochester\n" .
+                "Bag-size: very, very small\n" .
+                "DC-Author: Me\n" .
+                "DC-Author: Myself\n" .
+                "DC-Author: The other\n"
+            );
+            $bag = new BagIt($tmp2);
+
+            $bag->clearAllBagInfo();
+            
+            $this->assertNull($bag->getBagInfoData('Source-organization'));
+            $this->assertNull($bag->getBagInfoData('DC-Author'));
+        } catch (Exception $e) {
+            rrmdir($tmp2);
+            throw $e;
+        }
+        rrmdir($tmp2);
+    }
+    
+    public function testBagItGetBagInfoKeys() {
+        $this->assertEquals(0, count($this->bag->bagInfoData));
+
+        $tmp2 = tmpdir();
+        try
+        {
+            mkdir($tmp2);
+            $this->_createBagItTxt($tmp2);
+            file_put_contents(
+                $tmp2 . "/bag-info.txt",
+                "Source-organization: University of Virginia Alderman Library\n" .
+                "Contact-name: Eric Rochester\n" .
+                "Bag-size: very, very small\n" .
+                "DC-Author: Me\n" .
+                "DC-Author: Myself\n" .
+                "DC-Author: The other\n" .
+                " and more\n"
+            );
+            $bag = new BagIt($tmp2);
+            $keys = $bag->getBagInfoKeys();
+            sort($keys);
+            $expected = array('Bag-size', 'Contact-name', 'DC-Author', 'Source-organization');
+            $this->assertEquals($expected, $keys);
+
+            $this->assertTrue($bag->hasBagInfoData('DC-Author'));
+            $this->assertEquals(
+                array( 'Me', 'Myself', 'The other and more' ),
+                $bag->getBagInfoData('DC-Author')
+            );
+        }
+        catch (Exception $e)
+        {
+            rrmdir($tmp2);
+            throw $e;
+        }
+        rrmdir($tmp2);
+    }
 
     public function testBagInfoDuplicateDataWrite()
     {


### PR DESCRIPTION
 * $bag->getBagInfoKeys() which returns an unsorted list of bag info
keys
 * $bag->clearAllBagInfo() which deletes all the info data keys from the
bag-info.txt file in memory. You must call $bag->update() to persist the
changes to disk.

Also adds tests for the functions.

closes #16 