### PR TITLE
Remove line breaks from file encoding

### DIFF
--- a/lib/bagit_utils.php
+++ b/lib/bagit_utils.php
@@ -216,6 +216,8 @@ function findFirstExisting($fileNames, $default=null)
  */
 function readFileText($fileName, $fileEncoding)
 {
+    // Remove line breaks from $fileEncoding.
+    $fileEncoding = preg_replace( '/\r|\n/', '', $fileEncoding );
     $data = iconv($fileEncoding, 'UTF-8', file_get_contents($fileName));
     return $data;
 }


### PR DESCRIPTION
Ran into a scenario where the 'readFileText' function's $fileEncoding parameter contained a line break. Proposing to remove line breaks from $fileEncoding.