### PR TITLE
Trim file encodings

### DIFF
--- a/lib/bagit_utils.php
+++ b/lib/bagit_utils.php
@@ -363,7 +363,7 @@ function BagIt_parseEncodingString($bagitFileData)
     );
 
     if ($success) {
-        return $matches[1];
+        return trim($matches[1]);
     }
 
     return null;


### PR DESCRIPTION
Resolved #18 

@ghalusa I think this will resolve your issue. The major difference is it doesn't when we load the file encoding to ensure we don't let the character in at all.

If possible would you give it a try?