### PR TITLE
setting phpdocumentor version to 2.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",
-        "phpdocumentor/phpdocumentor": "2.*",
+        "phpdocumentor/phpdocumentor": "2.9.0",
         "pdepend/pdepend" : "2.1.0",
         "phpmd/phpmd" : "@stable",
         "sebastian/phpcpd": "*",


### PR DESCRIPTION
Composer and/or phpdocumentor/phpdocumentor seems to not like the 2.* version number anymore, I get was getting the following when running a ```composer install -vvv```
```
BagItPHP# /usr/local/bin/composer install -vvv
Reading ./composer.json
Loading config file ./composer.json
Checked CA file /etc/ssl/certs/ca-certificates.crt: valid
Failed to initialize global composer: Composer could not find the config file: /home/vagrant/.config/composer/composer.json
To initialize a project, please create a composer.json file as described in the https://getcomposer.org/ "Getting Started" section
Running 1.8.0 (2018-12-03 10:31:16) with PHP 7.2.24-0ubuntu0.18.04.1 on Linux / 4.15.0-33-generic
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Loading composer repositories with package information
Downloading https://repo.packagist.org/packages.json
Writing /home/vagrant/.cache/composer/repo/https---repo.packagist.org/packages.json into cache
Updating dependencies (including require-dev)
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2013.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2014.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2015.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2016.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2017.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2018.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2019-01.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2019-04.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2019-07.json from cache
Downloading http://repo.packagist.org/p/provider-2019-10%24636c82a6c83c0d9107feceab54afd1dedd8d3ad378a437b47168639a90107176.json
Writing /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-2019-10.json into cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-archived.json from cache
Downloading http://repo.packagist.org/p/provider-latest%24d9b1462e1e66f63b3a5e13c08550bb9b1abf9636bcc506e2800627708d6c148a.json
Writing /home/vagrant/.cache/composer/repo/https---repo.packagist.org/p-provider-latest.json into cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-scholarslab$bagit.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-pear$archive-tar.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-pear$pear-exception.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-pear$pear-core-minimal.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-pear$console-getopt.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpunit$phpunit.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpunit$php-file-iterator.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpunit$php-text-template.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpunit$php-code-coverage.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpunit$php-timer.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpunit$phpunit-mock-objects.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$yaml.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sebastian$comparator.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sebastian$diff.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sebastian$environment.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sebastian$exporter.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sebastian$global-state.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sebastian$version.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpunit$php-token-stream.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-doctrine$instantiator.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$polyfill-ctype.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sebastian$recursion-context.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpspec$prophecy.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$reflection-docblock.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-dflydev$markdown.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$reflection-common.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$type-resolver.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-webmozart$assert.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$phpdocumentor.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-cilex$cilex.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$validator.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-monolog$monolog.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-twig$twig.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$event-dispatcher.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-jms$serializer.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-stdlib.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-servicemanager.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-config.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-i18n.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-serializer.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-cache.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-filter.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$graphviz.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$fileset.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$reflection.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$template-abstract.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$template-clean.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$template-responsive-twig.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$template-responsive.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$template-new-black.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$template-zend.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$template-old-ocean.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$template-checkstyle.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$template-xml.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-pimple$pimple.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$process.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$finder.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-cilex$console-service-provider.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$translation.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$property-access.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$polyfill-mbstring.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-psr$log.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-jms$parser-lib.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpcollection$phpcollection.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-doctrine$annotations.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-jms$metadata.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-hydrator.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-container-interop$container-interop.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-json.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-math.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zendframework$zend-eventmanager.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-psr$cache.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-psr$simple-cache.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-nikic$php-parser.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpdocumentor$unified-asset-installer.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$console.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpoption$phpoption.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-doctrine$lexer.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-psr$container.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-athletic$athletic.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$debug.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$stopwatch.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$config.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$filesystem.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-erusev$parsedown.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-dompdf$dompdf.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zetacomponents$document.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phenx$php-font-lib.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phenx$php-svg-lib.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zetacomponents$base.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sabberworm$php-css-parser.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-knplabs$knp-menu.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-herrera-io$phar-update.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-herrera-io$json.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-kherge$version.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-justinrainbow$json-schema.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-seld$jsonlint.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$compiler.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$consistency.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$exception.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$file.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$iterator.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$math.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$protocol.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$regex.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$visitor.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$event.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$stream.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$zformat.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$ustring.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$core.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-hoa$string.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-pdepend$pdepend.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$dependency-injection.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$contracts.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$service-contracts.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-phpmd$phpmd.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sebastian$phpcpd.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-zetacomponents$console-tools.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-sebastian$finder-facade.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-theseer$fdomdocument.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-symfony$polyfill-php73.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-squizlabs$php-codesniffer.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-mayflower$php-codebrowser.json from cache
Resolving dependencies through SAT
Looking at all rules.
Something's changed, looking at all rules again (pass #10)
Dependency resolution completed in 4.419 seconds
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-dompdf$dompdf.json from cache
Reading /home/vagrant/.cache/composer/repo/https---repo.packagist.org/provider-dompdf$dompdf.json from cache
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - phpdocumentor/phpdocumentor v2.3.1 requires dompdf/dompdf dev-master@dev -> satisfiable by dompdf/dompdf[dev-master] but these conflict with your requirements or minimum-stability.
    - phpdocumentor/phpdocumentor v2.3.0 requires dompdf/dompdf dev-master@dev -> satisfiable by dompdf/dompdf[dev-master] but these conflict with your requirements or minimum-stability.
    - phpdocumentor/phpdocumentor v2.0.0 requires phpdocumentor/fileset 1.*@beta -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.0.1 requires phpdocumentor/fileset 1.*@beta -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.1.0 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.2.0 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.3.2 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.4.0 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.5.0 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.6.0 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.6.1 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.7.0 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.7.1 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.8.0 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.8.1 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.8.2 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.8.3 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.8.4 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.8.5 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - phpdocumentor/phpdocumentor v2.9.0 requires phpdocumentor/fileset ~1.0 -> satisfiable by phpdocumentor/fileset[1.0.0].
    - Conclusion: don't install phpdocumentor/fileset 1.0.0
    - Installation request for phpdocumentor/phpdocumentor 2.* -> satisfiable by phpdocumentor/phpdocumentor[v2.0.0, v2.0.1, v2.1.0, v2.2.0, v2.3.0, v2.3.1, v2.3.2, v2.4.0, v2.5.0, v2.6.0, v2.6.1, v2.7.0, v2.7.1, v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.9.0].
```